### PR TITLE
Allow link check failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -15,3 +15,6 @@ jobs:
         run: bundle
       - name: Build site
         run: bundle exec jekyll build
+      - name: Check Links
+        run: bundle exec rake check_links
+        continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,3 @@
-
 name: ubuntu
 
 on: [push, pull_request]
@@ -7,14 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: ruby/setup-ruby@v1
-      with:
-        bundler-cache: true
-        rubygems: latest
-    - name: Install dependencies
-      run: bundle
-    - name: Build site
-      run: bundle exec jekyll build
-    - name: Run tests
-      run: bundle exec rake check_links
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          rubygems: latest
+      - name: Install dependencies
+        run: bundle
+      - name: Build site
+        run: bundle exec jekyll build


### PR DESCRIPTION
Probably a bad idea for CI to fail when checking links. This allows the step to fail while still testing all our links. I can see us removing this the workflow in the future, but for now it's informative to see which links are not working.